### PR TITLE
Android App Fixes

### DIFF
--- a/evidence_collection.py
+++ b/evidence_collection.py
@@ -170,7 +170,9 @@ class AppInfo(Dictable):
         if self.app_name.strip() == "":
             self.app_name = title
         if self.app_name.strip() == "":
+            # both are empty, so use appId
             self.app_name = appId
+            self.title = appId
         self.appId = appId
         self.flags = flags
         self.application_icon = application_icon
@@ -1154,6 +1156,7 @@ def get_multiple_app_details(device, ser, apps):
     for app in apps:
         d = get_app_details(device, ser, app["id"])
         d["flags"] = app["flags"]
+        d["appId"] = app["id"]
         filled_in_apps.append(d)
     return filled_in_apps
 
@@ -1295,8 +1298,10 @@ def get_scan_data(device, device_owner):
 
     for k in apps.keys():
         app = apps[k]
-        app["id"] =k
+        app["id"] = k
         app["app_name"] = app["title"]
+        if app["app_name"].strip() == "":
+            app["app_name"] = k
         if 'dual-use' in app["flags"] or 'spyware' in app["flags"]:
             suspicious_apps.append(app)
         else:

--- a/phone_scanner/parse_dump.py
+++ b/phone_scanner/parse_dump.py
@@ -266,7 +266,8 @@ class AndroidDump(PhoneDump):
     # @staticmethod
     def parse_dump_file(self, fname) -> dict:
         if not Path(fname).exists():
-            print("File: {!r} does not exists".format(fname))
+            #print("File: {!r} does not exists".format(fname))
+            raise FileNotFoundError(fname)
         fp = open(fname)
         d = {}
         service = ""

--- a/phone_scanner/runcmd.py
+++ b/phone_scanner/runcmd.py
@@ -3,6 +3,7 @@ import re
 
 # import shlex
 import subprocess
+import sys
 
 """
 def add_to_error(*args):
@@ -91,13 +92,11 @@ def catch_err(
 def run_command(cmd, **kwargs):
     _cmd = cmd.format(cli="adb", **kwargs)
     print(_cmd)
+    p = subprocess.Popen(
+            _cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
+    )
+    # ric recommends later we use stdout=sys.stdout, stderr=sys.stderr, and subprocess.run instead
     if kwargs.get("nowait", False) or kwargs.get("NOWAIT", False):
-        pid = subprocess.Popen(
-            _cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
-        ).pid
-        return pid
+        return p.pid
     else:
-        p = subprocess.Popen(
-            _cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True
-        )
         return p

--- a/scripts/android_scan.sh
+++ b/scripts/android_scan.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 ## For scanning the phone and downloading some specific information of the phone
 ## Input: serial number 
@@ -39,8 +40,7 @@ export adb=$adb
 
 serial="-s $2"
 hmac_serial="-s $3"
-dump_dir="./phone_dumps"
-ofname=$dump_dir/${hmac_serial:3}_android.txt
+ofname="./phone_dumps/${3}_android.txt"
 
 email="^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$"
 function scan {

--- a/scripts/get_apk_common_name.sh
+++ b/scripts/get_apk_common_name.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+
 function android_pull_apk() {
     if [ -z "$1" ]; then
         echo "You must pass a package to this function!"

--- a/scripts/getnames.sh
+++ b/scripts/getnames.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+
 aaptversion='3.2.1-4818971'
 #wget https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/$aaptversion/aapt2-$aaptversion-osx.jar
 wget https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2/$aaptversion/aapt2-$aaptversion-linux.jar --no-check-certificate

--- a/scripts/ios_dump.sh
+++ b/scripts/ios_dump.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 platform='unknown'
 unamestr=`uname`

--- a/scripts/ios_dump.sh
+++ b/scripts/ios_dump.sh
@@ -12,7 +12,7 @@ elif [[ "$unamestr" == 'FreeBSD' ]]; then
    platform='freebsd'
 fi
 
-echo "$platform" "$adb"
+#echo "$platform" "$adb"
 
 serial=$(pymobiledevice3 usbmux list | awk -F'"' '/Identifier/ {print $4}')
 mkdir -p phone_dumps/"$1"_ios

--- a/scripts/pull_apks.sh
+++ b/scripts/pull_apks.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
 # Pulls all third party apks that are not present in pkg folder 
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"


### PR DESCRIPTION
Main fixes:
- [X] Android apps don't have names
- [X] Android app selection -> investigation page has apps that weren't selected? 
    - Issue had to do with the naming problem

Additional changes included:
- Add Ric's suggestion for robust bash scripts: `set -euo pipefail`
- Raise FileNotFound exception if dump file doesn't exist