### PR TITLE
Fixes to App Select-Investigate Pipeline

### DIFF
--- a/templates/evidence-scan.html
+++ b/templates/evidence-scan.html
@@ -6,6 +6,7 @@
 <script src="{{ url_for('static', filename='bootstrap.min.js') }}"></script>
 <script src="{{ url_for('static', filename='myjscript.js') }}?3"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/3.6.2/fetch.min.js"></script>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
 
 {% block content %}
 
@@ -40,6 +41,8 @@
                     </tbody>
                 </table>
                 <br>
+
+                <div id="loading" style="display:none;"><img src="../../../webstatic/images/waiting.gif" alt="" /></div>
 
             {% elif step == 2 %}
             <p><b>Evidence of jailbreaking?</b> {{"Yes" if is_rooted else "No"}}. <b>Explanation:</b> {{rooted_reasons}}</p>
@@ -247,7 +250,7 @@
                 <div><span class="secondarybutton">{{form.manualadd}}</span></div>
                 {% endif %}
 
-                <div><span class="primarybutton">{{form.submit}}</span></div>
+                <div><span class="primarybutton" onclick="$('#loading').show();">{{form.submit}}</span></div>
                 </form>
         </div>
     </div>

--- a/templates/evidence-scan.html
+++ b/templates/evidence-scan.html
@@ -18,6 +18,9 @@
             <div class="alert alert-warning">
                 <button type="button" class="close" data-dismiss="alert">&times;</button>
                 {{ message }}
+                {% if show_rescan %}
+                <a href="{{ url_for('evidence_scan_start', force_rescan=True, device_type=device, device_nickname=nickname) }}" class="btn btn-default">Go back and force a rescan</a>
+                {% endif %}
             </div>
             {% endfor %}
             <br>

--- a/web/view/evidence.py
+++ b/web/view/evidence.py
@@ -443,9 +443,10 @@ def evidence_scan_investigate(ser):
     current_scan = get_scan_by_ser(ser, all_scan_data)
     assert current_scan.serial == ser
 
-    pprint([app.to_dict() for app in current_scan.selected_apps])
-    pprint("INPUTTED INTO THE INVESTIGATION FORM")
-    # get apps to investigate from the scan data
+    for app in current_scan.selected_apps:
+        app = app.to_dict()
+        pprint("App: {}  Flags: {}".format(app["title"], app["flags"]))
+    pprint("INFO GIVEN TO INVESTIGATION FORM")
 
     form = AppInvestigationForm(selected_apps=[app.to_dict() for app in current_scan.selected_apps])
 
@@ -472,10 +473,15 @@ def evidence_scan_investigate(ser):
             # clean up the submitted data
             clean_data = remove_unwanted_data(form.data)
 
-            pprint(clean_data["selected_apps"])
+            # Update app info in selected_apps based on what was provided in the form
+            for app in current_scan.selected_apps:
+                for form_app in clean_data["selected_apps"]:
+                    if app.appId == form_app["appId"]:
+                        app.install_info = form_app["install_info"]
+                        app.permission_info.access = form_app["permission_info"]["access"]
+                        app.permission_info.describe = form_app["permission_info"]["describe"]
+                        app.notes = form_app["notes"]
 
-            # update the current scan data and save it
-            current_scan.selected_apps = [AppInfo(**app, device_hmac_serial=ser) for app in clean_data["selected_apps"]]
             all_scan_data = update_scan_by_ser(current_scan, all_scan_data)
 
             #  save this updated data

--- a/web/view/evidence.py
+++ b/web/view/evidence.py
@@ -329,18 +329,20 @@ def evidence_scan_select(ser):
             # get selected apps from the form data
             to_investigate_ids = [app["appId"] for app in form.data['apps'] if app['investigate']]
 
-            selected_apps = []
+            # remove apps we no longer want to investigate, 
+            # while maintaining info from previous investigations
+            current_scan.selected_apps = [app for app in current_scan.selected_apps 
+                                          if app.appId in to_investigate_ids]
+        
+            # Update "investigate" marker and add new apps to selected_apps
+            # TODO: Do we need the "investigate" marker?
             for app in current_scan.all_apps:
                 if app.appId in to_investigate_ids:
-                    selected_apps.append(app)
-                    app.investigate = True
+                    if not app.investigate:
+                        current_scan.selected_apps.append(app)
+                        app.investigate = True
                 else:
                     app.investigate = False
-
-            pprint(selected_apps)
-            pprint("SELECTED APPS")
-
-            current_scan.selected_apps = selected_apps
 
             # update the current scan data and save it as the most recent scan
             #current_scan.selected_apps = [AppInfo(**app) for app in selected_apps]


### PR DESCRIPTION
- [x] Ensure flags and permissions don't expand when saving investigation page
- [x] Don't overwrite investigation data when re-selecting
- [x] Option to force re-scan in edge cases
- [x] Add scan loading gif