### PR TITLE
Account Form Updates

### DIFF
--- a/evidence_collection.py
+++ b/evidence_collection.py
@@ -861,7 +861,7 @@ class DualUseAppForm(FlaskForm):
 
 ## HELPER FORMS FOR ACCOUNTS
 class SuspiciousLoginsForm(FlaskForm):
-    recognize = RadioField("Do you recognize all devices logged into this account?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
+    recognize = RadioField("Do you see any unrecognized devices that have logged into this account?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     describe_logins = TextAreaField("Which devices do you not recognize?")
     login_screenshot = MultipleFileField('Add screenshot(s)')
     activity_log = RadioField("In the login history, do you see any suspicious logins?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)

--- a/evidence_collection.py
+++ b/evidence_collection.py
@@ -874,18 +874,18 @@ class PasswordForm(FlaskForm):
 
 class RecoveryForm(FlaskForm):
     phone_present = RadioField("Is there a recovery phone number set for this account?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
-    phone = TextAreaField("If so, what is the recovery phone number?")
+    phone = TextAreaField("What is the recovery phone number?")
     phone_access = RadioField("Do you believe the person of concern has access to the recovery phone number?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     phone_screenshot = MultipleFileField('Add screenshot(s)')
     email_present = RadioField("Is there a recovery email address set for this account?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
-    email = TextAreaField("If so, what is the recovery email address?")
+    email = TextAreaField("What is the recovery email address?")
     email_access = RadioField("Do you believe the person of concern has access to this recovery email address?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     email_screenshot = MultipleFileField('Add screenshot(s)')
 
 class TwoFactorForm(FlaskForm):
     enabled = RadioField("Is two-factor authentication enabled for this account?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
     second_factor_type = RadioField("What type of two-factor authentication is it?", choices=TWO_FACTOR_CHOICES, default=TWO_FACTOR_DEFAULT)
-    describe = TextAreaField("If so, which phone/email/app is set as the second factor?")
+    describe = TextAreaField("Which phone/email/app is set as the second factor?")
     second_factor_access = RadioField("Do you believe the person of concern has access to this second factor?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     screenshot = MultipleFileField('Add screenshot(s)')
 

--- a/evidence_collection.py
+++ b/evidence_collection.py
@@ -823,7 +823,7 @@ class PermissionForm(FlaskForm):
 class InstallForm(FlaskForm):
     knew_installed = RadioField('Did you know this app was installed?', choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     installed = RadioField('Did you install this app?', choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
-    coerced = RadioField('Did your [ex-]partner coerce you into installing this app?', choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
+    coerced = RadioField('Did the person of concern coerce you into installing this app?', choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     #who = TextAreaField("If you were coerced, who coerced you?")
     screenshot = MultipleFileField('Add screenshot(s)')
 
@@ -869,30 +869,30 @@ class SuspiciousLoginsForm(FlaskForm):
     activity_screenshot = MultipleFileField('Add screenshot(s)')
 
 class PasswordForm(FlaskForm):
-    know = RadioField("Does your [ex-]partner know the password for this account?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
-    guess = RadioField("Do you believe your [ex-]partner could guess the password?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
+    know = RadioField("Does the person of concern know the password for this account?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
+    guess = RadioField("Do you believe the person of concern could guess the password?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
 
 class RecoveryForm(FlaskForm):
     phone_present = RadioField("Is there a recovery phone number set for this account?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
     phone = TextAreaField("What is the recovery phone number?")
-    phone_access = RadioField("Do you believe your [ex-]partner has access to the recovery phone number?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
+    phone_access = RadioField("Do you believe the person of concern has access to the recovery phone number?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     phone_screenshot = MultipleFileField('Add screenshot(s)')
     email_present = RadioField("Is there a recovery email address set for this account?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
     email = TextAreaField("What is the recovery email address?")
-    email_access = RadioField("Do you believe your [ex-]partner has access to this recovery email address?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
+    email_access = RadioField("Do you believe the person of concern has access to this recovery email address?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     email_screenshot = MultipleFileField('Add screenshot(s)')
 
 class TwoFactorForm(FlaskForm):
     enabled = RadioField("Is two-factor authentication enabled for this account?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
     second_factor_type = RadioField("What type of two-factor authentication is it?", choices=TWO_FACTOR_CHOICES, default=TWO_FACTOR_DEFAULT)
     describe = TextAreaField("Which phone/email/app is set as the second factor?")
-    second_factor_access = RadioField("Do you believe your [ex-]partner has access to this second factor?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
+    second_factor_access = RadioField("Do you believe the person of concern has access to this second factor?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     screenshot = MultipleFileField('Add screenshot(s)')
 
 class SecurityQForm(FlaskForm):
     present = RadioField("Does the account use security questions?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
     questions = TextAreaField("Which questions are set?")
-    know = RadioField("Do you believe your [ex-]partner knows the answer to any of these questions?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
+    know = RadioField("Do you believe the person of concern knows the answer to any of these questions?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     screenshot = MultipleFileField('Add screenshot(s)')
 
 class AccountInfoForm(FlaskForm):

--- a/evidence_collection.py
+++ b/evidence_collection.py
@@ -874,24 +874,24 @@ class PasswordForm(FlaskForm):
 
 class RecoveryForm(FlaskForm):
     phone_present = RadioField("Is there a recovery phone number set for this account?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
-    phone = TextAreaField("What is the recovery phone number?")
+    phone = TextAreaField("If so, what is the recovery phone number?")
     phone_access = RadioField("Do you believe the person of concern has access to the recovery phone number?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     phone_screenshot = MultipleFileField('Add screenshot(s)')
     email_present = RadioField("Is there a recovery email address set for this account?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
-    email = TextAreaField("What is the recovery email address?")
+    email = TextAreaField("If so, what is the recovery email address?")
     email_access = RadioField("Do you believe the person of concern has access to this recovery email address?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     email_screenshot = MultipleFileField('Add screenshot(s)')
 
 class TwoFactorForm(FlaskForm):
     enabled = RadioField("Is two-factor authentication enabled for this account?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
     second_factor_type = RadioField("What type of two-factor authentication is it?", choices=TWO_FACTOR_CHOICES, default=TWO_FACTOR_DEFAULT)
-    describe = TextAreaField("Which phone/email/app is set as the second factor?")
+    describe = TextAreaField("If so, which phone/email/app is set as the second factor?")
     second_factor_access = RadioField("Do you believe the person of concern has access to this second factor?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     screenshot = MultipleFileField('Add screenshot(s)')
 
 class SecurityQForm(FlaskForm):
     present = RadioField("Does the account use security questions?", choices=YES_NO_CHOICES, default=YES_NO_DEFAULT)
-    questions = TextAreaField("Which questions are set?")
+    questions = TextAreaField("Which questions might they be able to answer?")
     know = RadioField("Do you believe the person of concern knows the answer to any of these questions?", choices=YES_NO_UNSURE_CHOICES, default=YES_NO_DEFAULT)
     screenshot = MultipleFileField('Add screenshot(s)')
 

--- a/templates/_formhelpers.html
+++ b/templates/_formhelpers.html
@@ -13,12 +13,17 @@
   </dd>
 {% endmacro %}
 
-{% macro render_select(field) %}
+{% macro render_select(field, renderonyes) %}
 <tr class="form-question">
     <th>{{field.label}}</th>
     <td>
         {% for option in field %}
-        {% if option.label.text != "Nothing selected" %}
+        {% if option.label.text == "Yes" %}
+        <label class="btn btn-light" {% if renderonyes %} onclick="$('#wrapper-{{renderonyes}}').show();" {% endif %}> 
+            {{ option.label.text }}
+            {{ option }}
+        </label>
+        {% elif option.label.text != "Nothing selected" %}
         <label class="btn btn-light">
             {{ option.label.text }}
             {{ option }}
@@ -36,9 +41,13 @@
 </tr>
 {% endmacro %}
 
-{% macro render_text_field(field) %}
-<tr class="form-question">
-    <th>{{ field.label }}</th>
+{% macro render_text_field(field, ishidden) %}
+<tr class="form-question" id="wrapper-{{field.id}}" {% if ishidden %} style="display:none;" {% endif %}>
+    <th>
+        <div>
+        {{ field.label }}
+        </div>
+    </th>
     <td> {{ field }}</td>
 </tr>
 {% endmacro %}

--- a/templates/_formhelpers.html
+++ b/templates/_formhelpers.html
@@ -34,8 +34,8 @@
 </tr>
 {% endmacro %}
 
-{% macro render_multiselect(field) %}
-<tr class="form-question">
+{% macro render_multiselect(field, ishidden) %}
+<tr class="form-question" id="wrapper-{{field.id}}" {% if ishidden %} style="display:none;" {% endif %}>
     <th>{{field.label}}</th>
     <td class="multiselect-box">{{field}}</td>
 </tr>

--- a/templates/_formhelpers.html
+++ b/templates/_formhelpers.html
@@ -23,6 +23,11 @@
             {{ option.label.text }}
             {{ option }}
         </label>
+        {% elif option.label.text == "No" %}
+        <label class="btn btn-light" {% if renderonyes %} onclick="$('#wrapper-{{renderonyes}}').hide();" {% endif %}> 
+            {{ option.label.text }}
+            {{ option }}
+        </label>
         {% elif option.label.text != "Nothing selected" %}
         <label class="btn btn-light">
             {{ option.label.text }}

--- a/templates/_formhelpers.html
+++ b/templates/_formhelpers.html
@@ -40,19 +40,22 @@
 {% endmacro %}
 
 {% macro render_multiselect(field, ishidden) %}
-<tr class="form-question" id="wrapper-{{field.id}}" {% if ishidden %} style="display:none;" {% endif %}>
+<tr class="form-question" id="wrapper-{{field.id}}" 
+    {% if ishidden and field.data|length == 0 %} style="display:none;" {% endif %}>
     <th>{{field.label}}</th>
-    <td class="multiselect-box">{{field}}</td>
+    <td class="multiselect-box">{{field}} </td>
 </tr>
 {% endmacro %}
 
 {% macro render_text_field(field, ishidden) %}
-<tr class="form-question" id="wrapper-{{field.id}}" {% if ishidden %} style="display:none;" {% endif %}>
+<tr class="form-question" id="wrapper-{{field.id}}" 
+    {% if ishidden and field.data == "" %} style="display:none;" {% endif %}>
     <th>
         <div>
         {{ field.label }}
         </div>
     </th>
     <td> {{ field }}</td>
+    
 </tr>
 {% endmacro %}

--- a/templates/evidence-account.html
+++ b/templates/evidence-account.html
@@ -93,18 +93,33 @@
                             <div class="subform">
                                 <table>
                                     <tbody>
-                                    {{ render_select(form.recovery_settings.phone_present) }}
-                                    {{ render_select(form.recovery_settings.phone_access, 
-                                                     form.recovery_settings.phone.id) }}
-                                    {{ render_text_field(form.recovery_settings.phone, ishidden=True) }}
-                                    {{ render_select(form.recovery_settings.email_present) }}
-                                    {{ render_select(form.recovery_settings.email_access, 
-                                                     form.recovery_settings.email.id) }}
-                                    {{ render_text_field(form.recovery_settings.email, ishidden=True) }}
                                     <tr>
                                         <button id="account{{sessiondata.account_id}}_recovery_settings" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
                                         <button id="account{{sessiondata.account_id}}_recovery_settings" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
                                     </tr>
+                                    {{ render_select(form.recovery_settings.phone_present, "phonerecovery") }}
+                                    </tbody>
+                                </table>
+                                <table id="wrapper-phonerecovery" style="display:none;">
+                                    <tbody>
+                                    {{ render_select(form.recovery_settings.phone_access, 
+                                                     form.recovery_settings.phone.id) }}
+                                    {{ render_text_field(form.recovery_settings.phone, ishidden=True) }}
+                                    </tbody>
+                                </table>
+
+                                <table>
+                                    <tbody>
+                                    {{ render_select(form.recovery_settings.email_present, "emailrecovery") }}
+                                    </tbody>
+                                </table>
+                                <table id="wrapper-emailrecovery" style="display:none;">
+                                    <tbody>
+                                    {{ render_select(form.recovery_settings.email_access, 
+                                                     form.recovery_settings.email.id) }}
+                                    {{ render_text_field(form.recovery_settings.email, ishidden=True) }}
+                                    </tbody>
+                                </table>
                                     </tbody>
                                 </table>
                             </div>
@@ -121,9 +136,12 @@
                             <div class="subform">
                                 <table>
                                     <tbody>
-                                    {% for subform in [form.two_factor_settings.enabled, form.two_factor_settings.second_factor_type] %}
-                                    {{ render_select(subform) }}
-                                    {% endfor %}
+                                    {{ render_select(form.two_factor_settings.enabled, "twofactorquestions") }}
+                                    </tbody>
+                                </table>
+                                <table id="wrapper-twofactorquestions" style="display:none;">
+                                    <tbody>
+                                    {{ render_select(form.two_factor_settings.second_factor_type) }}
                                     {{ render_select(form.two_factor_settings.second_factor_access, 
                                                      form.two_factor_settings.describe.id) }}
                                     {{ render_text_field(form.two_factor_settings.describe, ishidden=True) }}
@@ -147,7 +165,11 @@
                             <div class="subform">
                                 <table>
                                     <tbody>
-                                    {{ render_select(form.security_questions.present) }}
+                                    {{ render_select(form.security_questions.present, "securityquestions") }}
+                                    </tbody>
+                                </table>
+                                <table id="wrapper-securityquestions" style="display:none;">
+                                    <tbody>
                                     {{ render_select(form.security_questions.know, 
                                                      form.security_questions.questions.id) }}
                                     {{ render_text_field(form.security_questions.questions, ishidden=True) }}
@@ -155,7 +177,7 @@
                                         <button id="account{{sessiondata.account_id}}_security_questions" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
                                         <button id="account{{sessiondata.account_id}}_security_questions" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
                                     </tr>
-                                    </tbody>
+                                     </tbody>
                                 </table>
                             </div>
                         </div>

--- a/templates/evidence-account.html
+++ b/templates/evidence-account.html
@@ -6,6 +6,7 @@
 <script src="{{ url_for('static', filename='bootstrap.min.js') }}"></script>
 <script src="{{ url_for('static', filename='myjscript.js') }}?3"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/3.6.2/fetch.min.js"></script>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"></script>
 
 {% block content %}
 
@@ -47,14 +48,16 @@
                             <div class="subform">
                                 <table>
                                     <tbody>
-                                    {{ render_select(form.suspicious_logins.recognize) }}
-                                    {{ render_text_field(form.suspicious_logins.describe_logins) }}
-                                    {{ render_select(form.suspicious_logins.activity_log) }}
-                                    {{ render_text_field(form.suspicious_logins.describe_activity) }}
+                                    {{ render_select(form.suspicious_logins.recognize, form.suspicious_logins.describe_logins.id) }}
+                                    {{ render_text_field(form.suspicious_logins.describe_logins, ishidden=True) }}
+                                    {{ render_select(form.suspicious_logins.activity_log, 
+                                                    form.suspicious_logins.describe_activity.id) }}
+                                    {{ render_text_field(form.suspicious_logins.describe_activity, ishidden=True) }}
                                     <tr>
                                         <button id="account{{sessiondata.account_id}}_suspicious_logins" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
                                         <button id="account{{sessiondata.account_id}}_suspicious_logins" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
                                     </tr>
+                                    <tr><div id="loading" style="display:none;"><img src="../../../webstatic/images/waiting.gif" alt="" /></div></tr>
                                     </tbody>
                                 </table>
                             </div>
@@ -90,14 +93,14 @@
                             <div class="subform">
                                 <table>
                                     <tbody>
-                                    {% for subform in [form.recovery_settings.phone_present, form.recovery_settings.phone_access] %}
-                                    {{ render_select(subform) }}
-                                    {% endfor %}
-                                    {{ render_text_field(form.recovery_settings.phone) }}
-                                    {% for subform in [form.recovery_settings.email_present, form.recovery_settings.email_access] %}
-                                    {{ render_select(subform) }}
-                                    {% endfor %}
-                                    {{ render_text_field(form.recovery_settings.email) }}
+                                    {{ render_select(form.recovery_settings.phone_present) }}
+                                    {{ render_select(form.recovery_settings.phone_access, 
+                                                     form.recovery_settings.phone.id) }}
+                                    {{ render_text_field(form.recovery_settings.phone, ishidden=True) }}
+                                    {{ render_select(form.recovery_settings.email_present) }}
+                                    {{ render_select(form.recovery_settings.email_access, 
+                                                     form.recovery_settings.email.id) }}
+                                    {{ render_text_field(form.recovery_settings.email, ishidden=True) }}
                                     <tr>
                                         <button id="account{{sessiondata.account_id}}_recovery_settings" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
                                         <button id="account{{sessiondata.account_id}}_recovery_settings" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
@@ -121,8 +124,9 @@
                                     {% for subform in [form.two_factor_settings.enabled, form.two_factor_settings.second_factor_type] %}
                                     {{ render_select(subform) }}
                                     {% endfor %}
-                                    {{ render_select(form.two_factor_settings.second_factor_access) }}
-                                    {{ render_text_field(form.two_factor_settings.describe) }}
+                                    {{ render_select(form.two_factor_settings.second_factor_access, 
+                                                     form.two_factor_settings.describe.id) }}
+                                    {{ render_text_field(form.two_factor_settings.describe, ishidden=True) }}
                                     <tr>
                                         <button id="account{{sessiondata.account_id}}_two_factor_settings" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
                                         <button id="account{{sessiondata.account_id}}_two_factor_settings" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
@@ -144,8 +148,9 @@
                                 <table>
                                     <tbody>
                                     {{ render_select(form.security_questions.present) }}
-                                    {{ render_select(form.security_questions.know) }}
-                                    {{ render_text_field(form.security_questions.questions) }}
+                                    {{ render_select(form.security_questions.know, 
+                                                     form.security_questions.questions.id) }}
+                                    {{ render_text_field(form.security_questions.questions, ishidden=True) }}
                                     <tr>
                                         <button id="account{{sessiondata.account_id}}_security_questions" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
                                         <button id="account{{sessiondata.account_id}}_security_questions" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>

--- a/templates/evidence-account.html
+++ b/templates/evidence-account.html
@@ -100,7 +100,11 @@
                                     {{ render_select(form.recovery_settings.phone_present, "phonerecovery") }}
                                     </tbody>
                                 </table>
-                                <table id="wrapper-phonerecovery" style="display:none;">
+                                <table id="wrapper-phonerecovery" 
+                                       {% if form.recovery_settings.phone_present.data  != "yes"  %} 
+                                       style="display:none;" 
+                                       {%endif%}
+                                        >
                                     <tbody>
                                     {{ render_select(form.recovery_settings.phone_access, 
                                                      form.recovery_settings.phone.id) }}
@@ -113,7 +117,11 @@
                                     {{ render_select(form.recovery_settings.email_present, "emailrecovery") }}
                                     </tbody>
                                 </table>
-                                <table id="wrapper-emailrecovery" style="display:none;">
+                                <table id="wrapper-emailrecovery" 
+                                       {% if form.recovery_settings.email_present.data != "yes" %} 
+                                       style="display:none;"
+                                       {%endif%}
+                                       >
                                     <tbody>
                                     {{ render_select(form.recovery_settings.email_access, 
                                                      form.recovery_settings.email.id) }}
@@ -139,7 +147,11 @@
                                     {{ render_select(form.two_factor_settings.enabled, "twofactorquestions") }}
                                     </tbody>
                                 </table>
-                                <table id="wrapper-twofactorquestions" style="display:none;">
+                                <table id="wrapper-twofactorquestions" 
+                                    {% if form.two_factor_settings.enabled.data != "yes" %} 
+                                    style="display:none;"
+                                    {% endif %}
+                                    >
                                     <tbody>
                                     {{ render_select(form.two_factor_settings.second_factor_type) }}
                                     {{ render_select(form.two_factor_settings.second_factor_access, 
@@ -168,7 +180,11 @@
                                     {{ render_select(form.security_questions.present, "securityquestions") }}
                                     </tbody>
                                 </table>
-                                <table id="wrapper-securityquestions" style="display:none;">
+                                <table id="wrapper-securityquestions" 
+                                    {% if form.security_questions.present.data != "yes" %} 
+                                    style="display:none;"
+                                    {% endif %}
+                                    >
                                     <tbody>
                                     {{ render_select(form.security_questions.know, 
                                                      form.security_questions.questions.id) }}

--- a/templates/evidence-account.html
+++ b/templates/evidence-account.html
@@ -27,43 +27,69 @@
 
             <h2>{{ form.title }}</h2>
             <br>
+            <table class="accountinfo">
+                <tbody>
                     <tr><th><h4>{{form.platform.label}}</h4></th><td>{{form.platform}}</td></tr>
-                    <tr><th><h4>{{form.account_nickname.label}}</h4></th><td>{{form.account_nickname}}</td></tr>
+                    <tr><th><h4>{{form.account_nickname.label}} (optional)</h4></th><td>{{form.account_nickname}}</td></tr>
+                </tbody>
+            </table>
                     <br/><br/>
                     {{ form.hidden_tag() }}
                     <div class="content">
-                        <h5>{{ form.suspicious_logins.label }}</h5>
-                        <div class="subform">
-                            {{form.suspicious_logins.hidden_tag()}}
-                            <button id="account{{sessiondata.account_id}}_suspicious_logins" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
-                            <button id="account{{sessiondata.account_id}}_suspicious_logins" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
-                            <table>
-                                <tbody>
+
+                    <details>
+                        <summary>
+                        <span class="icon">▼</span>
+                        <b>{{ form.suspicious_logins.label  }}</b>
+                        </summary>
+                        {{form.suspicious_logins.hidden_tag()}}
+                        <div class="content">
+                            <div class="subform">
+                                <table>
+                                    <tbody>
                                     {{ render_select(form.suspicious_logins.recognize) }}
                                     {{ render_text_field(form.suspicious_logins.describe_logins) }}
                                     {{ render_select(form.suspicious_logins.activity_log) }}
                                     {{ render_text_field(form.suspicious_logins.describe_activity) }}
-                                </tbody>
-                            </table>
+                                    <tr>
+                                        <button id="account{{sessiondata.account_id}}_suspicious_logins" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
+                                        <button id="account{{sessiondata.account_id}}_suspicious_logins" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
-                        <h5>{{ form.password_check.label }}</h5>
-                        <div class="subform">
-                            {{ form.password_check.hidden_tag() }}
-                            <table>
-                                <tbody>
+                    </details>
+
+                    <details>
+                        <summary>
+                        <span class="icon">▼</span>
+                        <b>{{ form.password_check.label  }}</b>
+                        </summary>
+                        {{form.password_check.hidden_tag()}}
+                        <div class="content">
+                            <div class="subform">
+                                <table>
+                                    <tbody>
                                     {% for subform in [form.password_check.know, form.password_check.guess] %}
                                     {{ render_select(subform) }}
                                     {% endfor %}
-                                </tbody>
-                            </table>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
-                        <h5>{{ form.recovery_settings.label }}</h5>
-                        <div class="subform">
-                            {{ form.recovery_settings.hidden_tag() }}
-                            <button id="account{{sessiondata.account_id}}_recovery_settings" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
-                            <button id="account{{sessiondata.account_id}}_recovery_settings" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
-                            <table>
-                                <tbody>
+                    </details>
+
+                    <details>
+                        <summary>
+                        <span class="icon">▼</span>
+                        <b>{{ form.recovery_settings.label  }}</b>
+                        </summary>
+                        {{form.recovery_settings.hidden_tag()}}
+                        <div class="content">
+                            <div class="subform">
+                                <table>
+                                    <tbody>
                                     {% for subform in [form.recovery_settings.phone_present, form.recovery_settings.phone_access] %}
                                     {{ render_select(subform) }}
                                     {% endfor %}
@@ -72,16 +98,26 @@
                                     {{ render_select(subform) }}
                                     {% endfor %}
                                     {{ render_text_field(form.recovery_settings.email) }}
-                                </tbody>
-                            </table>
+                                    <tr>
+                                        <button id="account{{sessiondata.account_id}}_recovery_settings" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
+                                        <button id="account{{sessiondata.account_id}}_recovery_settings" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
-                        <h5>{{ form.two_factor_settings.label }}</h5>
-                        <div class="subform">
-                            {{ form.two_factor_settings.hidden_tag() }}
-                            <button id="account{{sessiondata.account_id}}_two_factor_settings" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
-                            <button id="account{{sessiondata.account_id}}_two_factor_settings" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
-                            <table>
-                                <tbody>
+                    </details>
+
+                    <details>
+                        <summary>
+                        <span class="icon">▼</span>
+                        <b>{{ form.two_factor_settings.label  }}</b>
+                        </summary>
+                        {{form.two_factor_settings.hidden_tag()}}
+                        <div class="content">
+                            <div class="subform">
+                                <table>
+                                    <tbody>
                                     {% for subform in [form.two_factor_settings.enabled, form.two_factor_settings.second_factor_type] %}
                                     {{ render_select(subform) }}
                                     {% endfor %}
@@ -89,25 +125,45 @@
                                     {% with subform = form.two_factor_settings.second_factor_access %}
                                     {{ render_select(subform) }}
                                     {% endwith %}
-
-                                </tbody>
-                            </table>
+                                    <tr>
+                                        <button id="account{{sessiondata.account_id}}_two_factor_settings" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
+                                        <button id="account{{sessiondata.account_id}}_two_factor_settings" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
-                        <h5>{{ form.security_questions.label }}</h5>
-                        <div class="subform">
-                            {{ form.security_questions.hidden_tag() }}
-                                <button id="account{{sessiondata.account_id}}_security_questions" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
-                                <button id="account{{sessiondata.account_id}}_security_questions" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
-                            <table>
-                                <tbody>
+                    </details>
+
+                    <details>
+                        <summary>
+                        <span class="icon">▼</span>
+                        <b>{{ form.security_questions.label  }}</b>
+                        </summary>
+                        {{form.security_questions.hidden_tag()}}
+                        <div class="content">
+                            <div class="subform">
+                                <table>
+                                    <tbody>
                                     {{ render_select(form.security_questions.present) }}
                                     {{ render_text_field(form.security_questions.questions) }}
                                     {{ render_select(form.security_questions.know) }}
-                                </tbody>
-                            </table>
+                                    <tr>
+                                        <button id="account{{sessiondata.account_id}}_security_questions" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
+                                        <button id="account{{sessiondata.account_id}}_security_questions" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
+                                    </tr>
+                                    </tbody>
+                                </table>
+                            </div>
                         </div>
-                        <h5>{{form.notes.label}}</h5>
-                        <div class="subform notes">{{ form.notes }}</div>
+                    </details>
+
+
+                        <h3>{{form.notes.label}}</h3>
+                        {{form.notes.hidden_tag()}}
+                        <div class="content">
+                            <div class="subform notes">{{ form.notes }}</div>
+                        </div>
                     </div>
             <br>
             <div><span class="primarybutton">{{form.submit}}</span></div>

--- a/templates/evidence-account.html
+++ b/templates/evidence-account.html
@@ -121,10 +121,8 @@
                                     {% for subform in [form.two_factor_settings.enabled, form.two_factor_settings.second_factor_type] %}
                                     {{ render_select(subform) }}
                                     {% endfor %}
+                                    {{ render_select(form.two_factor_settings.second_factor_access) }}
                                     {{ render_text_field(form.two_factor_settings.describe) }}
-                                    {% with subform = form.two_factor_settings.second_factor_access %}
-                                    {{ render_select(subform) }}
-                                    {% endwith %}
                                     <tr>
                                         <button id="account{{sessiondata.account_id}}_two_factor_settings" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
                                         <button id="account{{sessiondata.account_id}}_two_factor_settings" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>
@@ -146,8 +144,8 @@
                                 <table>
                                     <tbody>
                                     {{ render_select(form.security_questions.present) }}
-                                    {{ render_text_field(form.security_questions.questions) }}
                                     {{ render_select(form.security_questions.know) }}
+                                    {{ render_text_field(form.security_questions.questions) }}
                                     <tr>
                                         <button id="account{{sessiondata.account_id}}_security_questions" type="button" onclick="getScreenshot(this.id, 'android', '{{android_ser}}')" value="screenshot">Android Screenshot</button>
                                         <button id="account{{sessiondata.account_id}}_security_questions" type="button" onclick="getScreenshot(this.id, 'ios', '{{ios_ser}}')" value="screenshot">iOS Screenshot</button>

--- a/templates/evidence-taq.html
+++ b/templates/evidence-taq.html
@@ -72,8 +72,9 @@
                             <table>
                                 <tbody>
                                     {{ render_text_field(form.accounts.pwd_mgmt) }}
-                                    {{ render_select(form.accounts.pwd_comp) }}
-                                    {{ render_text_field(form.accounts.pwd_comp_which) }}
+                                    {{ render_select(form.accounts.pwd_comp, 
+                                                     form.accounts.pwd_comp_which.id) }}
+                                    {{ render_text_field(form.accounts.pwd_comp_which, ishidden=True) }}
                                 </tbody>
                             </table>
                         </div>
@@ -91,10 +92,10 @@
                         <div class="subform">
                             <table>
                                 <tbody>
-                                    {{ render_select(form.sharing.share_phone_plan) }}
-                                    {{ render_multiselect(form.sharing.phone_plan_admin) }}
-                                    {{ render_select(form.sharing.share_accounts) }}
-                                    {{ render_text_field(form.sharing.share_which) }}
+                                    {{ render_select(form.sharing.share_phone_plan, form.sharing.phone_plan_admin.id) }}
+                                    {{ render_multiselect(form.sharing.phone_plan_admin, ishidden=True) }}
+                                    {{ render_select(form.sharing.share_accounts, form.sharing.share_which.id) }}
+                                    {{ render_text_field(form.sharing.share_which, ishidden=True) }}
                                 </tbody>
                             </table>
                         </div>

--- a/templates/evidence-taq.html
+++ b/templates/evidence-taq.html
@@ -113,7 +113,11 @@
                         <div class="subform">
                             <table>
                                 <tbody>
-                                    {{ render_select(form.smarthome.smart_home) }}
+                                    {{ render_select(form.smarthome.smart_home, "smarthomequestions") }}
+                                </tbody>
+                            </table>
+                            <table id="wrapper-smarthomequestions" style="display:none;">
+                                <tbody>
                                     {{ render_multiselect(form.smarthome.smart_home_setup) }}
                                     {{ render_select(form.smarthome.smart_home_access) }}
                                     {{ render_select(form.smarthome.smart_home_acct_sharing) }}
@@ -135,7 +139,11 @@
                         <div class="subform">
                             <table>
                                 <tbody>
-                                    {{ render_select(form.kids.custody) }}
+                                    {{ render_select(form.kids.custody, "childquestions") }}
+                                </tbody>
+                            </table>
+                            <table id="wrapper-childquestions" style="display:none;">
+                                <tbody>
                                     {{ render_select(form.kids.child_phys_access) }}
                                     {{ render_select(form.kids.child_phone_plan) }}
                                 </tbody>

--- a/web/view/evidence.py
+++ b/web/view/evidence.py
@@ -528,6 +528,7 @@ def evidence_account(id):
 
     form = AccountCompromiseForm()
 
+    # This is so that we can take screenshots if needed
     ios_scan_obj = IosScan()
     android_scan_obj = AndroidScan()
     ios_ser = None

--- a/webstatic/style.css
+++ b/webstatic/style.css
@@ -543,3 +543,7 @@ table.screenshots > tbody > tr > th > label {
 div.screenshotfail {
     background-color: goldenrod;
 }
+
+table.accountinfo > tbody > tr > th > h4 {
+    padding-right: 10px;
+}

--- a/webstatic/style.css
+++ b/webstatic/style.css
@@ -485,6 +485,7 @@ tr.form-question > th {
     width: 50%;
     vertical-align: top;
     padding-top: 5px;
+    font-weight: normal;
 }
 
 tr.form-question > td > select {


### PR DESCRIPTION
- [x] Make clear nickname is optional
- [x] Fix question ordering
- [x] Improve separation between sections
- [x] Only ask for text responses if compromise is indicated (using JS?)
    - [x] Link one select "Yes" to un-hiding one text or multiselect
        - [x] Rephrase q's so all of them make sense for Yes. E.g., "Do you recognize all devices" needs to be rephrased.
    - [x] Link one select "Yes" to un-hide a whole group of questions
        - TAQ: share custody, have smart home devices
        - Account: are there security q's, is there recovery phone/email, is there 2nd factor
- [x] Don't hide questions that were previously answered!